### PR TITLE
Fix crash when pkgJson is undefined

### DIFF
--- a/lib/checks/preReleases.js
+++ b/lib/checks/preReleases.js
@@ -1,6 +1,6 @@
 const { FatalError } = require("../errors");
 
-function checkForPreRelease(pkgJson) {
+function checkForPreRelease(pkgJson = {}) {
   const {
     dependencies = {},
     devDependencies = {},


### PR DESCRIPTION
### What does it do? Why?

👉🏻 &nbsp;Please add a description of what this `pull request` does.

Fix build https://github.com/mobsuccess-devops/github-mobsuccess-policy/actions/runs/3747069942/jobs/6362947174 

When pckgJson is undefined, a crash occurs

### Good To Know

👉🏻 &nbsp;Link to the asana ticket. Dont start a `pull request` without a ticket.

### QA

👉🏻 &nbsp;Please add what you think the reviewer has to test (remove this line and replace with your comment)

### Review

- [ ] All GHA are success - except Asana
- [ ] There is no new harcoded text, all has to be set with lingui
- [ ] Use react-ui when possible
- [ ] Costly calculations use `useMemo`
- [ ] The PR does not add svg, png, jpg but use streamline instead
- [ ] The PR does not add `eslint-disable` directives
- [ ] The Asana Changelog field has been set
