### PR TITLE
Add check for multiple packages (for monorepo)

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,16 +4,19 @@ const checkForWorkspaces = require("./lib/checks/workspaces");
 const hasMSBridgeConfig = require("./lib/checks/msbridge");
 const hasYarnLock = require("./lib/checks/yarn");
 const { FatalError } = require("./lib/errors");
-const { getPackageLock, getPackage } = require("./lib/utils");
+const { getPackageLock, getAllPackages } = require("./lib/utils");
 
 function lint() {
   const pkgLock = getPackageLock();
-  const pkgJson = getPackage();
+  const allPkgs = getAllPackages();
   const errors = [];
   errors.push(hasYarnLock());
   errors.push(checkLockVersion(pkgLock));
-  errors.push(checkForPreRelease(pkgJson));
-  errors.push(checkForWorkspaces(pkgJson));
+  allPkgs.forEach((pkg) => {
+    console.log(`Checking ${pkg.filename}`);
+    errors.push(checkForPreRelease(pkg.content));
+    errors.push(checkForWorkspaces(pkg.content));
+  });
   errors.push(hasMSBridgeConfig());
   for (const error of errors) {
     if (error instanceof FatalError) {

--- a/lib/checks/preReleases.js
+++ b/lib/checks/preReleases.js
@@ -8,7 +8,10 @@ function checkForPreRelease(pkgJson = {}) {
   } = pkgJson;
   const deps = { ...dependencies, ...devDependencies, ...peerDependencies };
   for (const [name, version] of Object.entries(deps)) {
-    if (/^@mobsuccess-devops/.test(name) && /-pr-(\d+)\.(\d+)$/.test(version)) {
+    if (
+      /^@mobsuccess-devops/.test(name) &&
+      /(-)+pr-(\d+)(\.(\d+))*$/.test(version) // matches -pr-1 or -pr-1.0 or -pr-1.0.0 or pr-1
+    ) {
       return new FatalError(
         `Unexpected pre-release dependency found: ${name}@${version}\n`
       );

--- a/lib/checks/preReleases.js
+++ b/lib/checks/preReleases.js
@@ -10,7 +10,7 @@ function checkForPreRelease(pkgJson = {}) {
   for (const [name, version] of Object.entries(deps)) {
     if (
       /^@mobsuccess-devops/.test(name) &&
-      /(-)+pr-(\d+)(\.(\d+))*$/.test(version) // matches -pr-1 or -pr-1.0 or -pr-1.0.0 or pr-1
+      /-?pr-(\d+)(\.(\d+))*$/.test(version) // matches -pr-1 or -pr-1.0 or -pr-1.0.0 or pr-1
     ) {
       return new FatalError(
         `Unexpected pre-release dependency found: ${name}@${version}\n`

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,4 @@
+const { spawnSync } = require("child_process");
 const { readFileSync } = require("fs");
 
 function getPackage() {
@@ -6,6 +7,32 @@ function getPackage() {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Return the list of all package.json files, except for those in node_modules folder. This is useful for monorepos.
+ */
+function getAllPackages() {
+  const result = spawnSync(
+    "find",
+    [".", "-name", "package.json", "-not", "-path", "./node_modules/*"],
+    { stdio: ["ignore", "pipe", "ignore"] }
+  );
+  if (result.status !== 0) {
+    throw new Error(`find command failed with status ${result.status}`);
+  }
+  const stdout = result.stdout.toString("utf-8");
+  let filenames = stdout.split("\n").filter((line) => line.length > 0);
+  filenames = filenames.map((filename) => filename.replace("./", ""));
+  const filesContent = filenames.map((filename) => {
+    return JSON.parse(readFileSync(filename).toString("utf-8"));
+  });
+  return filesContent.map((fileContent, index) => {
+    return {
+      filename: filenames[index],
+      content: fileContent,
+    };
+  });
 }
 
 function getPackageLock() {
@@ -18,5 +45,6 @@ function getPackageLock() {
 
 module.exports = {
   getPackage,
+  getAllPackages,
   getPackageLock,
 };


### PR DESCRIPTION
### What does it do? Why?

This make sure every package.json file is checked, and it improves the regex to catch those dependencies:
```
    "@mobsuccess-devops/lcm-react-client": "1.0.6014404762-pr-536",
    "@mobsuccess-devops/lcm-react-client": "pr-536",
```