### PR TITLE
Fix prerelease verifiction

### DIFF
--- a/lib/checks/preReleases.js
+++ b/lib/checks/preReleases.js
@@ -10,7 +10,8 @@ function checkForPreRelease(pkgJson = {}) {
   for (const [name, version] of Object.entries(deps)) {
     if (
       /^@mobsuccess-devops/.test(name) &&
-      /-?pr-(\d+)(\.(\d+))*$/.test(version) // matches -pr-1 or -pr-1.0 or -pr-1.0.0 or pr-1
+      (/-?pr-(\d+)(\.(\d+))*$/.test(version) || // matches -pr-1 or -pr-1.0 or -pr-1.0.0 or pr-1
+        /-?pr-backend-(\d+)(\.(\d+))*$/.test(version)) // matches -pr-backend-1 or -pr-backend-1.0 or -pr-backend-1.0.0
     ) {
       return new FatalError(
         `Unexpected pre-release dependency found: ${name}@${version}\n`


### PR DESCRIPTION
### What does it do? Why?

👉🏻 &nbsp;Make sure to fail GHA if -pr-backend prerelease tag is set in one of mobsuccess's packages version
