### PR TITLE
feat: disable npm updater

### DIFF
--- a/.mobsuccess.yml
+++ b/.mobsuccess.yml
@@ -1,0 +1,3 @@
+policy:
+  skip-updaters:
+    - npm


### PR DESCRIPTION
This pull request includes a small change to the `.mobsuccess.yml` file. The change adds a policy to skip updates for npm.

* [`.mobsuccess.yml`](diffhunk://#diff-cc8f4bbcfdd8bb94237b941e25222597112f9bf097ff7635bc0cdb9345e29558R1-R3): Added a policy to skip updates for npm.